### PR TITLE
Add threading support

### DIFF
--- a/keyserver/kssl_server.c
+++ b/keyserver/kssl_server.c
@@ -1,7 +1,7 @@
 // kssl_server.c: TLSv1.2 server for the CloudFlare Keyless SSL
 // protocol
 //
-// Copyright (c) 2013 CloudFlare, Inc.
+// Copyright (c) 2013-2014 CloudFlare, Inc.
 
 #include "kssl.h"
 #include "kssl_helpers.h"
@@ -147,21 +147,18 @@ typedef struct _connection_state {
   int connected;
 } connection_state;
 
-// Linked list of active connections
-connection_state *active = 0;
-
 // initialize_state: set the initial state on a newly created connection_state
-void initialize_state(connection_state *state)
+void initialize_state(connection_state **active, connection_state *state)
 {
   // Insert at the start of the list
-  state->prev = &active;
-  if (active) {
-    state->next = active;
-    active->prev = &state->next;
+  state->prev = active;
+  if (*active) {
+    state->next = *active;
+    (*active)->prev = &state->next;
   } else {
     state->next = 0;
   }
-  active = state;
+  *active = state;
 
   state->ssl = 0;
   state->start = 0;
@@ -269,11 +266,15 @@ void close_cb(uv_handle_t *tcp)
 {
   connection_state *state = (connection_state *)tcp->data;
 
-  SSL_free(state->ssl);
+  if (state != NULL) {
+    SSL_free(state->ssl);
+  }
 
   free(tcp);
-  free_read_state(state);
-  free(state);
+  if (state != NULL) {
+    free_read_state(state);
+    free(state);
+  }
 }
 
 // connection_terminate: terminate an SSL connection and remove from
@@ -581,14 +582,23 @@ void allocate_cb(uv_handle_t *h, size_t s, uv_buf_t *buf)
   }
 }
 
+typedef struct {
+  uv_sem_t    semaphore;    // Semaphore used in thread startup
+  uv_thread_t thread;       // The thread handle
+  uv_tcp_t    server;       // The TCP server listen handle
+  uv_async_t  stopper;      // Used to terminate threads
+  SSL_CTX *   ctx;          // The OpenSSL context
+  connection_state *active; // Active connection list
+} worker_data;
+
 // new_connection_cb: gets called when the listen socket for the
 // server is ready to read (i.e. there's an incoming connection).
 void new_connection_cb(uv_stream_t *server, int status)
 {
-  SSL_CTX *ctx;
   SSL *ssl;
   uv_tcp_t *client;
   connection_state *state;
+  worker_data *worker = (worker_data *)server->data;
 
   if (status == -1) {
     // TODO: should we log this?
@@ -596,6 +606,7 @@ void new_connection_cb(uv_stream_t *server, int status)
   }
 
   client = (uv_tcp_t *)malloc(sizeof(uv_tcp_t));
+  client->data = NULL;
   uv_tcp_init(server->loop, client);
   if (uv_accept(server, (uv_stream_t *)client) != 0) {
     uv_close((uv_handle_t *)client, close_cb);
@@ -603,13 +614,15 @@ void new_connection_cb(uv_stream_t *server, int status)
     return;
   }
 
+  // The TCP connection has been accept so now pass it off to a worker
+  // thread to handle
+
   state = (connection_state *)malloc(sizeof(connection_state));
-  initialize_state(state);
+  initialize_state(&worker->active, state);
   state->tcp = client;
   set_get_header_state(state);
 
-  ctx = (SSL_CTX *)server->data;
-  ssl = SSL_new(ctx);
+  ssl = SSL_new(worker->ctx);
   if (!ssl) {
     uv_close((uv_handle_t *)client, close_cb);
     write_log("[error] Failed to create SSL context");
@@ -641,21 +654,118 @@ void new_connection_cb(uv_stream_t *server, int status)
 
 int num_workers = DEFAULT_WORKERS;
 
+worker_data worker[MAX_WORKERS];
+
 // This is the TCP connection on which we listen for TLS connections
 
 uv_tcp_t tcp_server;
 
-// sigterm_cb: handle SIGTERM and terminates program cleanly
+// sigterm_cb: handle SIGTERM and terminates program cleanly. The
+// actual termination is handled in main once the uv_run has
+// exited. That will happen when this is called because we call
+// uv_signal_stop which is the last event handler running in the main
+// thread.
 void sigterm_cb(uv_signal_t *w, int signum)
 {
-  // TODO: terminate any existing connections
-
   uv_signal_stop(w);
-  uv_close((uv_handle_t *)&tcp_server, 0);
 }
 
-// cleanup: cleanup state. This is a function because it is needed by
-// children and parent.
+// thread_stop_cb: called via async_* to stop a thread
+void thread_stop_cb(uv_async_t* handle, int status) {
+  worker_data *worker = (worker_data *)handle->data;
+
+  uv_close((uv_handle_t*)&worker->server, NULL);
+  uv_close((uv_handle_t*)&worker->stopper, NULL);
+}
+
+typedef struct {
+  uv_pipe_t pipe;
+  uv_tcp_t *handle;
+  uv_connect_t connect_req;
+} ipc_client;
+
+// ipc_client_close_cb: called when the client has finished reading the
+// server handle from the pipe and has called uv_close()
+void ipc_client_close_cb(uv_handle_t *handle) {
+  ipc_client *client = (ipc_client *)handle->data;
+  free(client);
+}
+
+// ipc_read2_cb: data (the TCP server handle) ready to read on the pipe.
+// Read the handle and close the pipe.
+void ipc_read2_cb(uv_pipe_t* pipe,
+                  ssize_t nread,
+                  const uv_buf_t* buf,
+                  uv_handle_type type) {
+  ipc_client *client = (ipc_client *)pipe->data;
+  uv_loop_t *loop = pipe->loop;
+
+  uv_tcp_init(loop, (uv_tcp_t *)client->handle);
+  uv_accept((uv_stream_t*)&client->pipe, (uv_stream_t *)client->handle);
+  uv_close((uv_handle_t*)&client->pipe, NULL);
+}
+
+// ipc_connect_cb: call when a thread has made a connection to the IPC
+// server. Just reads the TCP server handle.
+void ipc_connect_cb(uv_connect_t* req, int status) {
+  ipc_client *client = (ipc_client *)req->data;
+  uv_read2_start((uv_stream_t*)&client->pipe, allocate_cb,
+                 ipc_read2_cb);
+}
+
+#if PLATFORM_WINDOWS
+#define PIPE_NAME "\\\\.\\pipe\\cloudflare-keyless"
+#else
+#define PIPE_NAME "/tmp/cloudflare-keyless"
+#endif
+
+void get_handle(uv_loop_t* loop, uv_tcp_t* server) {
+  ipc_client *client = (ipc_client *)malloc(sizeof(ipc_client));
+  client->handle = server;
+
+  client->connect_req.data = (void *)client;
+
+  uv_pipe_init(loop, &client->pipe, 1);
+  client->pipe.data = (void *)client;
+  uv_pipe_connect(&client->connect_req, &client->pipe,
+                  PIPE_NAME, ipc_connect_cb);
+}
+
+// thread_entry: starts a new thread and begins listening for
+// connections. Before listening it obtains the server handle from
+// the main thread.
+void thread_entry(void *data) {
+  worker_data *worker = (worker_data *)data;
+  uv_loop_t* loop = uv_loop_new();
+
+  // The stopper is used to terminate the thread gracefully. The
+  // uv_unref is here so that if the thread has terminated the
+  // async event doesn't keep the loop alive.
+
+  worker->stopper.data = (void *)worker;
+  uv_async_init(loop, &worker->stopper, thread_stop_cb);
+  uv_unref((uv_handle_t*)&worker->stopper);
+
+  // Wait for the main thread to be ready and obtain the
+  // server handle
+
+  uv_sem_wait(&worker->semaphore);
+  get_handle(loop, &worker->server);
+  uv_run(loop, UV_RUN_DEFAULT);
+  uv_sem_post(&worker->semaphore);
+
+  worker->server.data = (void *)worker;
+  worker->active = 0;
+
+  if (uv_listen((uv_stream_t *)&worker->server, SOMAXCONN,
+                new_connection_cb) == 0) {
+    uv_run(loop, UV_RUN_DEFAULT);
+  }
+
+  uv_loop_delete(loop);
+}
+
+// cleanup: cleanup state.
 void cleanup(uv_loop_t *loop, SSL_CTX *ctx, pk_list privates)
 {
   uv_loop_delete(loop);
@@ -673,6 +783,79 @@ void cleanup(uv_loop_t *loop, SSL_CTX *ctx, pk_list privates)
   CRYPTO_cleanup_all_ex_data();
   ERR_remove_state(0);
   ERR_free_strings();
+}
+
+typedef struct {
+  uv_pipe_t pipe;
+  uv_tcp_t  *server;
+  int       connects;
+} ipc_server;
+
+typedef struct {
+  uv_pipe_t pipe;
+  uv_write_t write_req;
+} ipc_peer;
+
+// ipc_close_cb: called when the uv_close in ipc_write_cb has
+// completed and frees memory allocated for the peer connection.
+void ipc_close_cb(uv_handle_t *handle) {
+  ipc_peer *peer = (ipc_peer *)handle->data;
+  free(peer);
+}
+
+// ipc_write_cb: called when the uv_write2 (sending the handle)
+// completes. Just closes the connection to the peer (i.e. the
+// thread).
+void ipc_write_cb(uv_write_t *req, int status) {
+  ipc_peer *peer = (ipc_peer *)req->data;
+  uv_close((uv_handle_t *)&peer->pipe, ipc_close_cb);
+}
+
+// ipc_connection_cb: called when a connection is made to the IPC
+// server. Connections come from worker threads requesting the listen
+// handle.
+void ipc_connection_cb(uv_stream_t *pipe, int status) {
+  ipc_server *server = (ipc_server *)pipe->data;
+  ipc_peer *peer = (ipc_peer *)malloc(sizeof(ipc_peer));
+  uv_loop_t *loop = pipe->loop;
+  uv_buf_t buf = uv_buf_init("ABCD", 4);
+
+  // Accept the connection on the pipe and immediately write the
+  // server handle to it using uv_write2 to send a handle
+
+  uv_pipe_init(loop, (uv_pipe_t*)&peer->pipe, 1);
+  uv_accept(pipe, (uv_stream_t*)&peer->pipe);
+  peer->write_req.data = (void *)peer;
+  peer->pipe.data = (void *)peer;
+  uv_write2(&peer->write_req, (uv_stream_t*)&peer->pipe,
+            &buf, 1, (uv_stream_t*)server->server,
+            ipc_write_cb);
+
+  // Decrement the connection counter. Once this reaches 0 it indicates
+  // that every thread has connected and obtained the server handle so
+  // the IPC server can be terminated.
+
+  server->connects -= 1;
+  if (server->connects == 0) {
+    uv_close((uv_handle_t*)pipe, NULL);
+  }
+}
+
+uv_mutex_t *locks;
+
+// thread_id_cb: used by OpenSSL to get the currently running thread's
+// ID
+unsigned long thread_id_cb(void) {
+  return uv_thread_self();
+}
+
+// locking_cb: used by OpenSSL to lock its internal data
+void locking_cb(int mode, int type, const char *file, int line) {
+  if (mode & CRYPTO_LOCK) {
+    uv_mutex_lock(&locks[type]);
+  } else {
+    uv_mutex_unlock(&locks[type]);
+  }
 }
 
 int main(int argc, char *argv[])
@@ -935,14 +1118,6 @@ int main(int argc, char *argv[])
 
   tcp_server.data = (char *)ctx;
 
-  if (uv_listen((uv_stream_t *)&tcp_server, SOMAXCONN, new_connection_cb) != 0) {
-    SSL_CTX_free(ctx);
-    fatal_error("Failed to listen on TCP socket");
-  }
-
-  uv_signal_init(loop, &sigterm_watcher);
-  uv_signal_start(&sigterm_watcher, sigterm_cb, SIGTERM);
-
   if (pid_file) {
     FILE *fp = fopen(pid_file, "w");
     if (fp) {
@@ -955,8 +1130,92 @@ int main(int argc, char *argv[])
     free(pid_file);
   }
 
+  // Make the worker threads
+
+  for (i = 0; i < num_workers; i++) {
+    if (uv_sem_init(&worker[i].semaphore, 0) != 0) {
+      SSL_CTX_free(ctx);
+      fatal_error("Failed to create semaphore");
+    }
+
+    worker[i].ctx = ctx;
+
+    if (uv_thread_create(&worker[i].thread, thread_entry,
+                         &worker[i]) != 0) {
+      SSL_CTX_free(ctx);
+      fatal_error("Failed to create worker thread");
+    }
+  }
+
+  // Create a pipe server which will hand the tcp_server handle
+  // to threads. Note the 1 in the third parameter of uv_pipe_init:
+  // that specifies that this pipe will be used to pass handles.
+
+  ipc_server *p = (ipc_server *)malloc(sizeof(ipc_server));
+  p->connects = num_workers;
+  p->server = &tcp_server;
+
+  if (uv_pipe_init(loop, &p->pipe, 1) != 0) {
+      SSL_CTX_free(ctx);
+      fatal_error("Failed to create pipe");
+  }
+  if (uv_pipe_bind(&p->pipe, PIPE_NAME) != 0) {
+      SSL_CTX_free(ctx);
+      fatal_error("Failed to bind pipe to name %s", PIPE_NAME);
+  }
+  p->pipe.data = (void *)p;
+  if (uv_listen((uv_stream_t*)&p->pipe, MAX_WORKERS,
+                ipc_connection_cb) != 0) {
+    SSL_CTX_free(ctx);
+    fatal_error("Failed to listen on pipe");
+  }
+
+  // Pass the tcp_server to all the worker threads and close it
+  // here as it is not needed in the main thread.
+
+  for (i = 0; i < num_workers; i++) {
+    uv_sem_post(&worker[i].semaphore);
+  }
   uv_run(loop, UV_RUN_DEFAULT);
+  uv_close((uv_handle_t*)&tcp_server, NULL);
+  uv_run(loop, UV_RUN_DEFAULT);
+  for (i = 0; i < num_workers; i++) {
+    uv_sem_wait(&worker[i].semaphore);
+  }
+
+  // The main thread will just wait around for SIGTERM
+
+  uv_signal_init(loop, &sigterm_watcher);
+  uv_signal_start(&sigterm_watcher, sigterm_cb, SIGTERM);
+
+  // Since we'll be running multiple threads OpenSSL needs mutexes
+  // as its state is shared across them.
+
+  locks = malloc(CRYPTO_num_locks() * sizeof(uv_mutex_t));
+
+  for ( i = 0; i < CRYPTO_num_locks(); i++) {
+    uv_mutex_init(&locks[i]);
+  }
+
+  CRYPTO_set_id_callback(thread_id_cb);
+  CRYPTO_set_locking_callback(locking_cb);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  // Now clean up all the running threads
+
+  for (i = 0; i < num_workers; i++) {
+    uv_async_send(&worker[i].stopper);
+    uv_thread_join(&worker[i].thread);
+    uv_sem_destroy(&worker[i].semaphore);
+  }
+
   cleanup(loop, ctx, privates);
+
+  for ( i = 0; i < CRYPTO_num_locks(); i++) {
+    uv_mutex_destroy(&locks[i]);
+  }
+  free(locks);
 
   return 0;
 }


### PR DESCRIPTION
This commit reinstates the --num_workers=n command-line parameter and uses it to
start n threads. Each thread handles kssl connections from a client and has its
own separate list of connections that it is handling.
