### PR TITLE
Document kssl_testclient options and add test-short Makefile target

### DIFF
--- a/keyserver/Makefile
+++ b/keyserver/Makefile
@@ -122,13 +122,17 @@ endif
 # presence or absence of the kssl_server.pid file (see above) and thus
 # it's necessary to restart make for them to do the right thing.
 
+.PHONY: test-short
+test-short: TEST_PARAMS := --short
+test-short: test
+
 test: export LD_LIBRARY_PATH=/usr/local/lib
 test: all
 	@$(MAKE) --no-print-directory kill
 	@$(MAKE) --no-print-directory run VALGRIND=$(VALGRIND) PORT=$(PORT)
 	@perl -e 'while (!-e "$(PID_FILE)") { sleep(1); }'
 	@sleep 1
-	@$(OBJ)kssl_testclient --port=$(PORT) --private-key=keys/private.key --client-cert=client-cert/cert.pem --client-key=client-cert/key.pem --ca-file=$(CA_FILE) $(DEBUG) --server=localhost
+	@$(OBJ)kssl_testclient --port=$(PORT) --private-key=keys/private.key --client-cert=client-cert/cert.pem --client-key=client-cert/key.pem --ca-file=$(CA_FILE) $(DEBUG) --server=localhost $(TEST_PARAMS)
 ifeq ($(VALGRIND),1)
 	@$(MAKE) --no-print-directory kill
 	@echo valgrind log in $(VALGRIND_LOG)

--- a/keyserver/kssl_testclient.c
+++ b/keyserver/kssl_testclient.c
@@ -1,6 +1,45 @@
 // kssl_testclient.c: test program to communicate with a keyserver
 //
-// Copyright (c) 2013 CloudFlare, Inc.
+// Copyright (c) 2013-2014 CloudFlare, Inc.
+//
+// Command-line options:
+//
+// --port
+//
+// TCP port to contact the kssl_server on (matches the --port parameter of
+// kssl_server)
+//
+// --server
+//
+// Hostname or IP of the kssl_server.
+//
+// --client-cert
+// --client-key
+//
+// The filenames of a client certificate to present to the server to verify
+// that this client is a valid user of kssl_server. These must be signed by a
+// CA that kssl_server can check the certificate against (i.e one in the
+// --ca-file parameter of kssl_server).
+//
+// --ca-file
+//
+// Path to a PEM-encoded file containing the CA certificate used to verify
+// server certificates presented on connection.
+// 
+// --private-key
+//
+// The filename of an RSA private key file (PEM encoded) that is used for
+// testing. This must be one of the private keys specified in the
+// kssl_server's --private-key-directory.
+//
+// --debug
+//
+// Turns in debug logging
+//
+// --short
+//
+// Instead of performing all the tests this simply checks connectivity with
+// the kssl_server by running a limit number of tests.
 
 #include "kssl.h"
 #include "kssl_helpers.h"
@@ -946,7 +985,7 @@ int main(int argc, char *argv[])
     fatal_error("The --private-key parameter must be specified with the path to private key file which contains the public key to be used for encryption");
   }
   if (!client_cert) {
-    fatal_error("The --client-cert parameter must be specified with a sign client certificate file name");
+    fatal_error("The --client-cert parameter must be specified with a signed client certificate file name");
   }
   if (!server) {
     fatal_error("The --server must be specified");


### PR DESCRIPTION
The kssl_testclient parameters were previously undocumented and are
now documented in a comment at the start of kssl_testclient.c.

Added a test-short Makefile target that is the same as test but only
performs a small number of tests by setting the --short parameter on
the kssl_testclient. This can be handy for simple connectivity tests.
