### PR TITLE
Add --version option to kssl_server

### DIFF
--- a/keyserver/Makefile
+++ b/keyserver/Makefile
@@ -6,6 +6,7 @@ NAME      := kssl_server
 VERSION   := 1.0
 ITERATION := $(shell date +%s)
 REVISION  := $(shell git log -n1 --pretty=format:%h)
+TODAY     := $(shell date --iso-8601=minutes --utc)
 
 TMP := tmp/
 
@@ -36,6 +37,7 @@ OPENSSL_LOG := $(TMP)openssl.log
 
 CFLAGS += -g -Wall -Wextra -Wno-unused-parameter -Werror
 CFLAGS += -I. -I$(LIBUV_INCLUDE) -I$(OPENSSL_INCLUDE)
+CFLAGS += -DKSSL_VERSION=\"v$(VERSION)\",\"$(TODAY)\",\"$(REVISION)\"
 
 # Link against OpenSSL and libuv. libuv is built and linked against
 # statically.

--- a/keyserver/kssl_server.c
+++ b/keyserver/kssl_server.c
@@ -425,6 +425,7 @@ int main(int argc, char *argv[])
     {"user",                  required_argument, 0, 12},
     {"daemon",                no_argument,       0, 13},
     {"syslog",                no_argument,       0, 14},
+    {"version",               no_argument,       0, 15},
 #endif
     {0,                       0,                 0, 0}
   };
@@ -569,6 +570,10 @@ int main(int argc, char *argv[])
       break;
 
 #endif
+
+    case 15:
+      fatal_error("kssl_server: %s %s %s", KSSL_VERSION );
+      break;
     }
   }
 


### PR DESCRIPTION
This outputs the current version (defined in the Makefile as
VERSION), the build date/time in ISO8601 format UTC, and the
current SHA from git log.

For example,

```
kssl_server: v1.0 2014-04-29T09:50+0000 bed307b
```
