### PR TITLE
Handle all errors in the read_cb and terminate connection

### DIFF
--- a/keyserver/kssl_thread.c
+++ b/keyserver/kssl_thread.c
@@ -446,7 +446,7 @@ void read_cb(uv_stream_t *s, ssize_t nread, const uv_buf_t *buf)
     BIO_write(state->read_bio, buf->base, nread);
   }
 
-  if (nread == UV_EOF) {
+  if ((nread == UV_EOF) || (nread < 0)) {
     connection_terminate(state->tcp);
   } else {
     if (do_ssl(state)) {


### PR DESCRIPTION
Previously, we were only checking for UV_EOF. But if an error
occurred other than UV_EOF it was possible for us to continue
reading from the connection and end up terminating the kssl_server
with a libuv exception:

```
uv_read: Assertion `!uv_io_active(&stream->io_watcher, 1)
&& "stream->read_cb(status=-1) did not call uv_close()"'
```

(Internal CloudFlare note: this is KEY-12)
