### PR TITLE
Work on KEY-18. Add --test to check configuration without running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ This is the keyserver for Keyless SSL. It consists of a single binary file
   to 1.
 - `--pid-file` (optional) Path to a file into which the PID of the
   keyserver. This file is only written if the keyserver starts successfully.
+- `--test` (optional) Run through program start up and check that the keyless
+  server is correctly configured. Returns 0 if good, 1 if an error.
 
 The following options are not available on Windows systems:
 


### PR DESCRIPTION
If --test is specified on the command-line then keyless will do
all the work necessary to start running (loading private keys,
binding to a TCP port, starting workers) without actually running.

It will give a 0 exit code if it would have started without the
--test command-line option and output an error message and return
1 if there was a problem with starting.

--test disables --daemon.
