### PR TITLE
bugfix: disabled dtrace in the libuv build because it caused issues when recent versions of systemtap is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ LIBUV_DIR := $(call marker,$(LIBUV_ROOT)/)
 .PHONY: libuv
 libuv: $(LIBUV_A)
 $(LIBUV_A): $(call marker,$(TMP)) $(LIBUV_DIR)
-	@cd $(LIBUV_ROOT) && ./autogen.sh && ./configure --enable-static && $(MAKE)
+	@cd $(LIBUV_ROOT) && ./autogen.sh && ./configure --enable-static --disable-dtrace && $(MAKE)
 
 $(LIBUV_DIR): $(call marker,$(TMP))
 	@rm -rf $(LIBUV_ROOT)


### PR DESCRIPTION
Without this patch, the build fails on my side with recent versions of systemtap installed in the same system:

```
make[1]: Entering directory `/home/agentzh/git/cf/nginx-fl/lua/keyless/tmp/libuv-1daff47ae9df55902f07d3c5b8a3a393306a2f1e'
GEN include/uv-dtrace.h
/opt/systemtap/bin/dtrace invalid option -xnolibs
Usage /opt/systemtap/bin/dtrace [--help] [-h | -G] [-C [-I<Path>]] -s File.d [-o <File>]
make[1]: *** [include/uv-dtrace.h] Error 1
make[1]: Leaving directory `/home/agentzh/git/cf/nginx-fl/lua/keyless/tmp/libuv-1daff47ae9df55902f07d3c5b8a3a393306a2f1e'
make: *** [tmp/libuv-1daff47ae9df55902f07d3c5b8a3a393306a2f1e/.libs/libuv.a] Error 2
```

Basically, the `dtrace` utility from recent versions of systemtap no longer supports the `-xnolibs` option.
