### PR TITLE
KEY-44 - Raw RSA Decrypt operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following opcodes are supported in the opcode item:
     0x05 - operation: RSA sign SHA256
     0x06 - operation: RSA sign SHA384
     0x07 - operation: RSA sign SHA512
+    0x08 - operation: RSA raw decrypt payload
     0x12 - operation: ECDSA sign MD5SHA1
     0x13 - operation: ECDSA sign SHA1
     0x14 - operation: ECDSA sign SHA224

--- a/kssl.h
+++ b/kssl.h
@@ -61,8 +61,9 @@ typedef struct {
 #define KSSL_OP_PING 0xF1
 #define KSSL_OP_PONG 0xF2
 
-// Decrypt data encrypted using RSA with RSA_PKCS1_PADDING
-#define KSSL_OP_RSA_DECRYPT 0x01
+// Decrypt data encrypted using RSA with or without RSA_PKCS1_PADDING
+#define KSSL_OP_RSA_DECRYPT          0x01
+#define KSSL_OP_RSA_DECRYPT_RAW      0x08
 
 // Sign data using RSA
 #define KSSL_OP_RSA_SIGN_MD5SHA1     0x02

--- a/kssl_core.c
+++ b/kssl_core.c
@@ -74,6 +74,7 @@ kssl_error_code kssl_operate(kssl_header *header,
 
     // Decrypt or sign the payload using the private key
     case KSSL_OP_RSA_DECRYPT:
+    case KSSL_OP_RSA_DECRYPT_RAW:
     case KSSL_OP_RSA_SIGN_MD5SHA1:
     case KSSL_OP_RSA_SIGN_SHA1:
     case KSSL_OP_RSA_SIGN_SHA224:

--- a/kssl_helpers.c
+++ b/kssl_helpers.c
@@ -424,6 +424,8 @@ const char *opstring(BYTE op) {
     return "KSSL_OP_PONG";
   case KSSL_OP_RSA_DECRYPT:
     return "KSSL_OP_RSA_DECRYPT";
+  case KSSL_OP_RSA_DECRYPT_RAW:
+    return "KSSL_OP_RSA_DECRYPT_RAW";
   case KSSL_OP_RESPONSE:
     return "KSSL_OP_RESPONSE";
   case KSSL_OP_RSA_SIGN_MD5SHA1:

--- a/kssl_private_key.c
+++ b/kssl_private_key.c
@@ -306,15 +306,18 @@ kssl_error_code private_key_operation(pk_list list,         // Private key array
   RSA *rsa;
   EC_KEY *ec_key;
   int digest_nid;
+  int padding;
+  int s;
   // Currently, we only support decrypt or sign here
 
-  if (opcode == KSSL_OP_RSA_DECRYPT) {
+  if (opcode == KSSL_OP_RSA_DECRYPT || opcode == KSSL_OP_RSA_DECRYPT_RAW) {
     rsa = EVP_PKEY_get1_RSA(list->privates[key_id].key);
       if (rsa == NULL) {
         ERR_clear_error();
         return KSSL_ERROR_CRYPTO_FAILED;
       }
-    int s = RSA_private_decrypt(length, message, out, rsa,  RSA_PKCS1_PADDING);
+    padding = (opcode == KSSL_OP_RSA_DECRYPT_RAW ? RSA_NO_PADDING : RSA_PKCS1_PADDING);
+    s = RSA_private_decrypt(length, message, out, rsa, padding);
     if (s != -1) {
       *size = (unsigned int)s;
     } else {


### PR DESCRIPTION
Add support for disabling PKCS#1 1.5 padding check on the keyless server to prevent adaptive chosen-ciphertext padding oracle attacks.
