### PR TITLE
Create SKI tag matching X509 SubjectKeyIdentifier and replace DIGEST.

### DIFF
--- a/kssl.h
+++ b/kssl.h
@@ -38,6 +38,7 @@ typedef struct {
                                  // digest_public_key)
 #define KSSL_TAG_SNI        0x02 // Server name (optional)
 #define KSSL_TAG_CLIENT_IP  0x03 // Client IP (4 bytes for IPv4, 16 for IPv6)
+#define KSSL_TAG_SKI        0x04 // Public key SKI
 #define KSSL_TAG_OPCODE     0x11 // Requested operation (one of KSSL_OP_*)
 #define KSSL_TAG_PAYLOAD    0x12 // Payload
 

--- a/kssl_core.c
+++ b/kssl_core.c
@@ -92,13 +92,15 @@ kssl_error_code kssl_operate(kssl_header *header,
       int max_payload_size;
       int key_id;
 
-      if (request.is_digest_set == 0) {
+      if (request.is_ski_set) {
+        // Identify private key from request ski
+        key_id = find_private_key(privates, request.ski, NULL);
+      } else if (request.is_digest_set) {
+        key_id = find_private_key(privates, NULL, request.digest);
+      } else {
         err = KSSL_ERROR_FORMAT;
         break;
       }
-
-      // Identify private key from request digest
-      key_id = find_private_key(privates, request.digest);
       if (key_id < 0) {
         err = KSSL_ERROR_KEY_NOT_FOUND;
         break;

--- a/kssl_helpers.h
+++ b/kssl_helpers.h
@@ -17,12 +17,15 @@
 // Helper macros for known sizes of V1 items
 #define KSSL_OPCODE_ITEM_SIZE (KSSL_ITEM_HEADER_SIZE + 1)
 #define KSSL_ERROR_ITEM_SIZE (KSSL_ITEM_HEADER_SIZE + 1)
+#define KSSL_SKI_SIZE 20
 #define KSSL_DIGEST_SIZE 32
 
 // Structure containing request information parsed from payload
 typedef struct kssl_operation_ {
   int is_opcode_set;
   BYTE opcode;
+  int is_ski_set;
+  BYTE *ski;
   int is_digest_set;
   BYTE *digest;
   int is_payload_set;

--- a/kssl_private_key.h
+++ b/kssl_private_key.h
@@ -36,12 +36,13 @@ kssl_error_code add_key_from_buffer(
   int         key_len,  // Length of key in bytes
   pk_list     list);    // Array of private keys 
 
-// find_private_key: returns an id for the key that matches the digest.
+// find_private_key: returns an id for the key that matches the ski.
 // In this implementation key id is the index into the list of privates.
 // A negative return indicates an error.
 int find_private_key(
-  pk_list     list,     // Array of private keys from new_pk_list
-  BYTE       *digest);  // Digest of key to search for (see digest_public_key)
+  pk_list     list,         // Array of private keys from new_pk_list
+  BYTE       *ski,          // SKI of key searched for (see get_ski)
+  BYTE       *digest);      // Digest of key searched for (see digest_public_key)
 
 // private_key_operation: perform a private key operation
 kssl_error_code private_key_operation(


### PR DESCRIPTION
This is a more cross-platform (i.e. non-OpenSSL), standardized way to uniquely identify a public key (of arbitrary type). And it gives a much more sensible way that what is currently being used for SSL keys.

For backwards compatibility, the DIGEST tag is still accepted, and can even be sent alongside the SKI tag (SKI will be preferred if both are sent). It can seamlessly removed in the future, or ignored if both sides support the newer Keyless protocol 

(Note: It's feels a bit odd to "downgrade" from SHA-256 to SHA-1, but that was what was standardized on in [RFC 5280 §4.2.1.2.](https://tools.ietf.org/html/rfc5280#section-4.2.1.2), and it should be fine as it's not being used for "secure" hash benefits anyway, just as a unique identifier)